### PR TITLE
Allow category and categories to pass through

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,8 @@ class SendGridTransport {
                     case 'subject':
                     case 'text':
                     case 'html':
+                    case 'category':
+                    case 'categories':
                         msg[key] = source[key];
                         break;
                     case 'from':


### PR DESCRIPTION
Sendgrid supports categories, and this will allow you to specify them in the message.