### PR TITLE
Change value key in content array from content to value

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ class SendGridTransport {
                         {
                             let alternatives = source.alternatives.map(entry => {
                                 let alternative = {
-                                    content: entry.content,
+                                    value: entry.content,
                                     type: entry.contentType
                                 };
                                 return alternative;
@@ -91,7 +91,7 @@ class SendGridTransport {
                     case 'watchHtml':
                         {
                             let alternative = {
-                                content: source.watchHtml,
+                                value: source.watchHtml,
                                 type: 'text/watch-html'
                             };
                             msg.content = [].concat(msg.content || []).concat(alternative);
@@ -113,13 +113,13 @@ class SendGridTransport {
             });
 
             if (msg.content && msg.content.length) {
-                if (msg.text) {
-                    msg.content.unshift({ type: 'text/plain', content: msg.text });
-                    delete msg.text;
-                }
                 if (msg.html) {
-                    msg.content.unshift({ type: 'text/html', content: msg.html });
+                    msg.content.unshift({ type: 'text/html', value: msg.html });
                     delete msg.html;
+                }
+                if (msg.text) {
+                    msg.content.unshift({ type: 'text/plain', value: msg.text });
+                    delete msg.text;
                 }
             }
 


### PR DESCRIPTION
Recently had issues with this. Turns out sendgrid uses 'value' instead of 'content' in the content array to store values. In addition the require the content array to be a specific order (text, html, ...others). This fixes that.

Stumbled upon this issue while trying to make inline ical events for outlook. 

Error from sendgrid:
```
  The content value must be a string at least one character in length.
    content.0.value
    http://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/errors.html#message.content.value
  The content value must be a string at least one character in length.
    content.1.value
    http://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/errors.html#message.content.value
  The content value must be a string at least one character in length.
    content.2.value
    http://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/errors.html#message.content.value
```

Some sendgrid documentation: https://github.com/sendgrid/sendgrid-nodejs/blob/master/docs/use-cases/manual-content.md


If some poor soul out there is fighting outlook, this is how i added the events to nodemailer + sendgrid:

```
    icalEvent: {
      // need to base64 encode for sendgrid to be happy
      content: Buffer.from(calendarEventString).toString("base64"),
      filename: "invite.ics",
      method,
      encoding: "base64",
    },
    alternatives: [
      {
        // ical-generator adds line breaks (correctly) to the attachment. But quoted-printable
        // encoding which is applied to the inline event adds its own line breaks. So we remove these
        // and let sendgrid do the work
        content: calendarEventString.replace(/(\r\n )/g, ""),
        contentType: `text/calendar; method=${method}`,
      },
    ],
```