### PR TITLE
Isolate SendGrid MailService used, so it does not use the global one

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,16 @@
 'use strict';
 
 const packageData = require('./package.json');
-const sgMail = require('@sendgrid/mail');
+const { MailService } = require('@sendgrid/mail');
 
 class SendGridTransport {
     constructor(options) {
         this.options = options || {};
         this.name = packageData.name;
         this.version = packageData.version;
+        this.sgMail = new MailService();
         if (options.apiKey) {
-            sgMail.setApiKey(options.apiKey);
+            this.sgMail.setApiKey(options.apiKey);
         }
     }
 
@@ -123,7 +124,7 @@ class SendGridTransport {
                 }
             }
 
-            sgMail.send(msg, callback);
+            this.sgMail.send(msg, callback);
         });
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,16 +6,19 @@
     "scripts": {
         "test": "grunt"
     },
-    "keywords": ["nodemailer", "sendgrid"],
+    "keywords": [
+        "nodemailer",
+        "sendgrid"
+    ],
     "author": "Andris Reinman",
     "license": "MIT",
     "dependencies": {
-        "@sendgrid/mail": "^6.2.1"
+        "@sendgrid/mail": "^7.4.4"
     },
     "devDependencies": {
         "eslint-config-nodemailer": "^1.2.0",
         "grunt": "^1.0.2",
-        "grunt-eslint": "^20.1.0",
-        "nodemailer": "^4.6.3"
+        "grunt-eslint": "^23.0.0",
+        "nodemailer": "^6.6.1"
     }
 }


### PR DESCRIPTION
This isolates the SendGrid MailService used inside the Transport class, to prevent the transport class using the global SendGrid MailService, allowing multiple Transports to use multiple MailServices with different API keys

Fixes #13 